### PR TITLE
Better API error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func (c APIClient) do(req *http.Request) ([]byte, error) {
 	if res.StatusCode != http.StatusOK {
 		var err Errors
 		if err := json.Unmarshal(data, &err); err != nil {
-			return nil, errors.New("request failed, could not unmarshal error response")
+			return nil, errors.Errorf("request failed, could not unmarshal error response. Raw error: %s", string(data))
 		}
 
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -88,8 +87,12 @@ func (c APIClient) do(req *http.Request) ([]byte, error) {
 
 	// TODO: Figure out how to properly return this error and remove log.
 	if res.StatusCode != http.StatusOK {
-		log.Println(string(data))
-		return nil, errors.New("request failed")
+		var err Errors
+		if err := json.Unmarshal(data, &err); err != nil {
+			return nil, errors.New("request failed, could not unmarshal error response")
+		}
+
+		return nil, err
 	}
 
 	return data, nil

--- a/error.go
+++ b/error.go
@@ -15,7 +15,7 @@ type Error struct {
 func (e Error) Error() string {
 	var errorText string
 	if e.Field != "" {
-		errorText = fmt.Sprintf("With field %s, ", e.Field)
+		errorText = fmt.Sprintf("With field '%s', ", e.Field)
 	}
 
 	return errorText + e.Reason
@@ -23,13 +23,15 @@ func (e Error) Error() string {
 
 // Errors is the full error response that Linode returns on 4xx and 5xx status codes. It
 // aliases a slice of Error structs so that the go error interface can be fulfilled.
-type Errors []Error
+type Errors struct {
+	Errors []Error `json:"errors"`
+}
 
 // Error implements the go error interface for Errors.
 func (e Errors) Error() string {
-	errorTexts := make([]string, len(e))
+	errorTexts := make([]string, len(e.Errors))
 
-	for i, err := range e {
+	for i, err := range e.Errors {
 		errorTexts[i] = err.Error()
 	}
 

--- a/error.go
+++ b/error.go
@@ -1,0 +1,37 @@
+package lingo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// An Error is the structured error type that Linode returns on 4xx and 5xx status codes.
+type Error struct {
+	Field  string `json:"field,omitempty"`
+	Reason string `json:"reason"`
+}
+
+// Error implements the go error interface for Errors.
+func (e Error) Error() string {
+	var errorText string
+	if e.Field != "" {
+		errorText = fmt.Sprintf("With field %s, ", e.Field)
+	}
+
+	return errorText + e.Reason
+}
+
+// Errors is the full error response that Linode returns on 4xx and 5xx status codes. It
+// aliases a slice of Error structs so that the go error interface can be fulfilled.
+type Errors []Error
+
+// Error implements the go error interface for Errors.
+func (e Errors) Error() string {
+	errorTexts := make([]string, len(e))
+
+	for i, err := range e {
+		errorTexts[i] = err.Error()
+	}
+
+	return strings.Join(errorTexts, "\n")
+}

--- a/error.go
+++ b/error.go
@@ -29,11 +29,12 @@ type Errors struct {
 
 // Error implements the go error interface for Errors.
 func (e Errors) Error() string {
-	errorTexts := make([]string, len(e.Errors))
+	errorTexts := make([]string, len(e.Errors)+1)
+	errorTexts[0] = "Linode API Error: "
 
 	for i, err := range e.Errors {
-		errorTexts[i] = err.Error()
+		errorTexts[i+1] = err.Error()
 	}
 
-	return strings.Join(errorTexts, "\n")
+	return strings.Join(errorTexts, "\n\t")
 }


### PR DESCRIPTION
Up until now the API client has just been logging raw JSON whenever errors happen. This was always temporary, as the library shouldn't be logging things to stdout and the calling code gets no insight into what error occurred.

There are now custom error types that the APIClient will attempt to marshal errors into and return, rather than logging. If the error that comes back is not structured properly, the APIClient will return a generic error that states the response could not be marshaled, along with the raw response data that was returned instead.