### PR TITLE
Exponential backoff

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,68 @@
+package lingo
+
+import (
+	"errors"
+	"time"
+)
+
+type backoffConfig struct {
+	retries uint
+	attempt uint
+
+	base uint
+	cap  uint
+}
+
+// NewBackoffConfig returns a new backoffConfig struct.
+func NewBackoffConfig(retries, base, cap uint) backoffConfig {
+	return backoffConfig{
+		retries: retries,
+		base:    base,
+		cap:     cap,
+	}
+}
+
+func (c *backoffConfig) Retry() error {
+	c.attempt++
+	if c.attempt > c.retries {
+		return errors.New("Backoff failed")
+	}
+
+	minimum := min(c.cap, exp(c.base*2, c.attempt))
+	time.Sleep(time.Duration(minimum) * time.Millisecond)
+
+	return nil
+}
+
+// Reset resets the backoff attempt counter.
+func (c *backoffConfig) Reset() {
+	c.attempt = 0
+}
+
+func exp(x, n uint) uint {
+	if n == 0 {
+		return 1
+	}
+
+	y := uint(1)
+	for n > 1 {
+		if n%2 == 0 {
+			x = x * x
+			n = n / 2
+		} else {
+			y = x * y
+			x = x * x
+			n = (n - 1) / 2
+		}
+	}
+
+	return x * y
+}
+
+func min(x, y uint) uint {
+	if x <= y {
+		return x
+	}
+
+	return y
+}

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_Integration_Balancers(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewBalancerClient(api)
 
 	createRequest1 := lingo.CreateBalancerRequest{

--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ type Results struct {
 
 // NewAPIClient returns a new Linode client struct loaded with the given
 // API key.
-func NewAPIClient(apiKey string, backoff bool) APIClient {
+func NewAPIClient(apiKey string, backoff *backoffConfig) APIClient {
 	// TODO: Build a Client struct here instead of using the default.
 	return APIClient{
 		apiKey: apiKey,
@@ -169,7 +169,7 @@ type Lingo struct {
 }
 
 // NewLingo returns a new Lingo struct given a Linode API key.
-func NewLingo(apiKey string, backoff bool) Lingo {
+func NewLingo(apiKey string, backoff *backoffConfig) Lingo {
 	api := NewAPIClient(apiKey, backoff)
 
 	return Lingo{

--- a/client.go
+++ b/client.go
@@ -151,8 +151,12 @@ type Lingo struct {
 	BalancerClient
 	ImageClient
 	RegionClient
+	DomainClient
+	VolumeClient
+	DiskClient
 }
 
+// NewLingo returns a new Lingo struct given a Linode API key.
 func NewLingo(apiKey string) Lingo {
 	api := NewAPIClient(apiKey)
 
@@ -161,5 +165,8 @@ func NewLingo(apiKey string) Lingo {
 		BalancerClient: NewBalancerClient(api),
 		ImageClient:    NewImageClient(api),
 		RegionClient:   NewRegionClient(api),
+		DomainClient:   NewDomainClient(api),
+		VolumeClient:   NewVolumeClient(api),
+		DiskClient:     NewDiskClient(api),
 	}
 }

--- a/disk.go
+++ b/disk.go
@@ -49,8 +49,8 @@ type CreateDiskRequest struct {
 
 // An UpdateDiskRequest wraps up the data that can be updated on a Linode Disk.
 type UpdateDiskRequest struct {
+	ID         uint       `json:"-"`
 	LinodeID   uint       `json:"-"`
-	DiskID     uint       `json:"id"`
 	Label      string     `json:"label,omitempty"`
 	FileSystem FileSystem `json:"filesystem,omitempty"`
 }

--- a/disk_client.go
+++ b/disk_client.go
@@ -111,7 +111,7 @@ func (c DiskClient) ResetDiskRootPassword(req UpdateDiskRequest) (Disk, error) {
 		return disk, errors.Wrap(err, "failed to marshal request for ResetDiskRootPassword")
 	}
 
-	data, err := c.api.Post(fmt.Sprintf("linode/instances/%d/disks/%d/password", req.LinodeID, req.DiskID), payload)
+	data, err := c.api.Post(fmt.Sprintf("linode/instances/%d/disks/%d/password", req.LinodeID, req.ID), payload)
 	if err != nil {
 		return disk, errors.Wrap(err, "failed to make request for ResetDiskRootPassword")
 	}

--- a/disk_test.go
+++ b/disk_test.go
@@ -15,7 +15,7 @@ func Test_Disks(t *testing.T) {
 	client := lingo.NewDiskClient(api)
 	linodeClient := lingo.NewLinodeClient(api)
 
-	createLinode := lingo.NewLinode{
+	createLinode := lingo.CreateLinodeRequest{
 		Region:   "us-east-1a",
 		Type:     "g5-standard-2",
 		Image:    "linode/debian9",
@@ -64,7 +64,7 @@ func Test_Disks(t *testing.T) {
 
 	updateReq := lingo.UpdateDiskRequest{
 		LinodeID: testLinode.ID,
-		DiskID:   disk1.ID,
+		ID:       disk1.ID,
 		Label:    "This is a meh label",
 	}
 
@@ -87,7 +87,7 @@ func Test_ResizeDisk(t *testing.T) {
 	client := lingo.NewDiskClient(api)
 	linodeClient := lingo.NewLinodeClient(api)
 
-	createLinode := lingo.NewLinode{
+	createLinode := lingo.CreateLinodeRequest{
 		Region:   "us-east-1a",
 		Type:     "g5-standard-2",
 		Image:    "linode/debian9",

--- a/disk_test.go
+++ b/disk_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_Disks(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewDiskClient(api)
 	linodeClient := lingo.NewLinodeClient(api)
 
@@ -83,7 +83,7 @@ func Test_Disks(t *testing.T) {
 
 func Test_ResizeDisk(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewDiskClient(api)
 	linodeClient := lingo.NewLinodeClient(api)
 

--- a/domain_test.go
+++ b/domain_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_CRUDDomain(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewDomainClient(api)
 
 	existing, err := client.ListDomains()
@@ -75,7 +75,7 @@ func Test_CRUDDomain(t *testing.T) {
 
 func Test_CRUDDomainRecord(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewDomainClient(api)
 
 	newDomain := lingo.Domain{

--- a/error.go
+++ b/error.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const busyText = "Linode busy."
+
 // An Error is the structured error type that Linode returns on 4xx and 5xx status codes.
 type Error struct {
 	Field  string `json:"field,omitempty"`
@@ -37,4 +39,22 @@ func (e Errors) Error() string {
 	}
 
 	return strings.Join(errorTexts, "\n\t")
+}
+
+func (e Error) IsBusy() bool {
+	if e.Reason == busyText {
+		return true
+	}
+
+	return false
+}
+
+func (e Errors) IsBusy() bool {
+	for _, err := range e.Errors {
+		if err.IsBusy() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/image_test.go
+++ b/image_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_ListImages(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewImageClient(api)
 
 	if _, err := client.ListImages(); err != nil {
@@ -25,7 +25,7 @@ func Test_ListImages(t *testing.T) {
 
 func Test_Image(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewImageClient(api)
 	linodeClient := lingo.NewLinodeClient(api)
 	diskClient := lingo.NewDiskClient(api)

--- a/linode.go
+++ b/linode.go
@@ -54,7 +54,7 @@ type Linode struct {
 	Updatd     Time       `json:"updated"`
 }
 
-type NewLinode struct {
+type CreateLinodeRequest struct {
 	Region          string          `json:"region"`
 	Type            string          `json:"type"`
 	Label           string          `json:"label,omitempty"`
@@ -66,9 +66,16 @@ type NewLinode struct {
 	Image           string          `json:"image,omitempty"`
 	BackupsEnabled  bool            `json:"backups_enabled"`
 	Booted          bool            `json:"booted"`
+	SwapSize        uint            `json:"swap_size,omitempty"`
 }
 
-type CloneRequest struct {
+type UpdateLinodeRequest struct {
+	ID     uint   `json:"-"`
+	Label  string `json:"label,omitempty"`
+	Alerts Alerts `json:"alerts,omitempty"`
+}
+
+type CloneLinodeRequest struct {
 	ID             uint     `json:"-"`
 	Region         string   `json:"region"`
 	Type           string   `json:"type"`
@@ -79,7 +86,7 @@ type CloneRequest struct {
 	Configs        []string `json:"configs,omitempty"`
 }
 
-type RebuildRequest struct {
+type RebuildLinodeRequest struct {
 	ID              uint            `json:"-"`
 	Image           string          `json:"image"`
 	RootPass        string          `json:"root_pass"`
@@ -122,9 +129,10 @@ type LinodeType struct {
 }
 
 type Linoder interface {
-	GetLinodes() ([]Linode, error)
-	GetLinode(id uint) (Linode, error)
-	CreateLinode(linode NewLinode) (Linode, error)
+	ListLinodes() ([]Linode, error)
+	ViewLinode(id uint) (Linode, error)
+	CreateLinode(req CreateLinodeRequest) (Linode, error)
+	UpdateLinode(req UpdateLinodeRequest)
 	DeleteLinode(id uint) error
 	BootLinode(id uint) error
 	BootLinodeWithConfig(id, configID uint) error
@@ -135,7 +143,7 @@ type Linoder interface {
 	GetType(id string) (LinodeType, error)
 	ResizeLinode(id uint, typeID string) error
 	Mutate(id uint) error
-	CloneLinode(req CloneRequest) (Linode, error)
-	RebuildLinode(req RebuildRequest) error
+	CloneLinode(req CloneLinodeRequest) (Linode, error)
+	RebuildLinode(req RebuildLinodeRequest) error
 	GetLinodeVolumes(id uint) ([]Volume, error)
 }

--- a/linode_client.go
+++ b/linode_client.go
@@ -16,7 +16,7 @@ func NewLinodeClient(api APIClient) LinodeClient {
 	return LinodeClient{api: api}
 }
 
-func (c LinodeClient) CreateLinode(linode NewLinode) (Linode, error) {
+func (c LinodeClient) CreateLinode(linode CreateLinodeRequest) (Linode, error) {
 	var created Linode
 
 	payload, err := json.Marshal(&linode)
@@ -36,35 +36,55 @@ func (c LinodeClient) CreateLinode(linode NewLinode) (Linode, error) {
 	return created, nil
 }
 
-func (c LinodeClient) GetLinodes() ([]Linode, error) {
+func (c LinodeClient) UpdateLinode(req UpdateLinodeRequest) (Linode, error) {
+	var updated Linode
+
+	payload, err := json.Marshal(&req)
+	if err != nil {
+		return updated, errors.Wrap(err, "failed to marshal request for UpdateLinode")
+	}
+
+	data, err := c.api.Put(fmt.Sprintf("linode/instances/%d", req.ID), payload)
+	if err != nil {
+		return updated, errors.Wrap(err, "failed to make request for UpdateLinode")
+	}
+
+	if err := json.Unmarshal(data, &updated); err != nil {
+		return updated, errors.Wrap(err, "failed to decode UpdateLinode response")
+	}
+
+	return updated, nil
+}
+
+func (c LinodeClient) ListLinodes() ([]Linode, error) {
 	data, err := c.api.Get("linode/instances")
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to make request for GetLinodes")
+		return nil, errors.Wrap(err, "failed to make request for ListLinodes")
 	}
 
 	var results Results
 	if err := json.Unmarshal(data, &results); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal GetLinodes response")
+		return nil, errors.Wrap(err, "failed to unmarshal ListLinodes response")
 	}
 
 	var linodes []Linode
 	if err := json.Unmarshal(results.Data, &linodes); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal GetLinodes data")
+		return nil, errors.Wrap(err, "failed to unmarshal ListLinodes data")
 	}
 
 	return linodes, nil
 }
 
-func (c LinodeClient) GetLinode(id uint) (Linode, error) {
+func (c LinodeClient) ViewLinode(id uint) (Linode, error) {
 	var linode Linode
 
 	data, err := c.api.Get(fmt.Sprintf("linode/instances/%d", id))
 	if err != nil {
-		return linode, errors.Wrap(err, "failed to make request for GetLinode")
+		return linode, errors.Wrap(err, "failed to make request for ViewLinode")
 	}
 
 	if err := json.Unmarshal(data, &linode); err != nil {
-		return linode, errors.Wrap(err, "failed to decode GetLinode response")
+		return linode, errors.Wrap(err, "failed to decode ViewLinode response")
 	}
 
 	return linode, nil
@@ -196,7 +216,7 @@ func (c LinodeClient) Mutate(id uint, typeID string) error {
 	return nil
 }
 
-func (c LinodeClient) CloneLinode(req CloneRequest) (Linode, error) {
+func (c LinodeClient) CloneLinode(req CloneLinodeRequest) (Linode, error) {
 	var clone Linode
 
 	payload, err := json.Marshal(req)
@@ -216,7 +236,7 @@ func (c LinodeClient) CloneLinode(req CloneRequest) (Linode, error) {
 	return clone, nil
 }
 
-func (c LinodeClient) RebuildLinode(req RebuildRequest) (Linode, error) {
+func (c LinodeClient) RebuildLinode(req RebuildLinodeRequest) (Linode, error) {
 	var linode Linode
 
 	payload, err := json.Marshal(req)

--- a/linode_test.go
+++ b/linode_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_Integration_Linodes(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewLinodeClient(api)
 
 	createLinode1 := lingo.CreateLinodeRequest{
@@ -67,7 +67,7 @@ func Test_Integration_Linodes(t *testing.T) {
 
 func Test_ListTypes(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewLinodeClient(api)
 
 	types, err := client.ListTypes()
@@ -89,7 +89,7 @@ func Test_ListTypes(t *testing.T) {
 
 func Test_BootLinode(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewLinodeClient(api)
 
 	createLinode := lingo.CreateLinodeRequest{
@@ -130,7 +130,7 @@ func Test_BootLinode(t *testing.T) {
 
 func Test_ResizeLinode(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewLinodeClient(api)
 
 	newType := "g5-standard-1"
@@ -160,7 +160,7 @@ func Test_ResizeLinode(t *testing.T) {
 
 func Test_CloneLinode(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewLinodeClient(api)
 
 	createLinode := lingo.CreateLinodeRequest{
@@ -202,7 +202,7 @@ func Test_CloneLinode(t *testing.T) {
 
 func Test_RebuildLinode(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewLinodeClient(api)
 
 	createLinode := lingo.CreateLinodeRequest{

--- a/linode_test.go
+++ b/linode_test.go
@@ -14,14 +14,14 @@ func Test_Integration_Linodes(t *testing.T) {
 	api := lingo.NewAPIClient(apiKey)
 	client := lingo.NewLinodeClient(api)
 
-	createLinode1 := lingo.NewLinode{
+	createLinode1 := lingo.CreateLinodeRequest{
 		Region:   "us-east-1a",
 		Type:     "g5-nanode-1",
 		Image:    "linode/debian9",
 		RootPass: "test123",
 	}
 
-	createLinode2 := lingo.NewLinode{
+	createLinode2 := lingo.CreateLinodeRequest{
 		Region:   "us-west",
 		Type:     "g5-nanode-1",
 		Image:    "linode/debian9",
@@ -38,7 +38,7 @@ func Test_Integration_Linodes(t *testing.T) {
 		t.Fatalf("Failed to create linode2: %s", err)
 	}
 
-	_, err = client.GetLinode(created1.ID)
+	_, err = client.ViewLinode(created1.ID)
 	if err != nil {
 		t.Fatalf("Failed to fetch linode1: %s", err)
 	}
@@ -47,7 +47,7 @@ func Test_Integration_Linodes(t *testing.T) {
 		t.Fatalf("Failed to fetch linode types: %s", err)
 	}
 
-	linodes, err := client.GetLinodes()
+	linodes, err := client.ListLinodes()
 	if err != nil {
 		t.Fatalf("Failed to fetch linodes: %s", err)
 	}
@@ -92,7 +92,7 @@ func Test_BootLinode(t *testing.T) {
 	api := lingo.NewAPIClient(apiKey)
 	client := lingo.NewLinodeClient(api)
 
-	createLinode := lingo.NewLinode{
+	createLinode := lingo.CreateLinodeRequest{
 		Region:   "us-east-1a",
 		Type:     "g5-nanode-1",
 		Image:    "linode/debian9",
@@ -134,7 +134,7 @@ func Test_ResizeLinode(t *testing.T) {
 	client := lingo.NewLinodeClient(api)
 
 	newType := "g5-standard-1"
-	createLinode := lingo.NewLinode{
+	createLinode := lingo.CreateLinodeRequest{
 		Region:   "us-east-1a",
 		Type:     "g5-nanode-1",
 		Image:    "linode/debian9",
@@ -163,7 +163,7 @@ func Test_CloneLinode(t *testing.T) {
 	api := lingo.NewAPIClient(apiKey)
 	client := lingo.NewLinodeClient(api)
 
-	createLinode := lingo.NewLinode{
+	createLinode := lingo.CreateLinodeRequest{
 		Region:   "us-east-1a",
 		Type:     "g5-nanode-1",
 		Image:    "linode/debian9",
@@ -177,7 +177,7 @@ func Test_CloneLinode(t *testing.T) {
 		t.Fatalf("Failed to create linode: %s", err)
 	}
 
-	cloneRequest := lingo.CloneRequest{
+	cloneRequest := lingo.CloneLinodeRequest{
 		ID:     testLinode.ID,
 		Region: testLinode.Region,
 		Type:   testLinode.Type,
@@ -205,7 +205,7 @@ func Test_RebuildLinode(t *testing.T) {
 	api := lingo.NewAPIClient(apiKey)
 	client := lingo.NewLinodeClient(api)
 
-	createLinode := lingo.NewLinode{
+	createLinode := lingo.CreateLinodeRequest{
 		Region:   "us-east-1a",
 		Type:     "g5-nanode-1",
 		Image:    "linode/debian9",
@@ -219,7 +219,7 @@ func Test_RebuildLinode(t *testing.T) {
 		t.Fatalf("Failed to create linode: %s", err)
 	}
 
-	rebuildRequest := lingo.RebuildRequest{
+	rebuildRequest := lingo.RebuildLinodeRequest{
 		ID:       testLinode.ID,
 		Image:    "linode/centos7",
 		RootPass: "test123",
@@ -246,7 +246,7 @@ func waitUntilOffline(client lingo.LinodeClient, id uint) error {
 }
 
 func waitUntil(client lingo.LinodeClient, id uint, status lingo.Status) error {
-	linode, err := client.GetLinode(id)
+	linode, err := client.ViewLinode(id)
 	if err != nil {
 		return err
 	}

--- a/region_test.go
+++ b/region_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_Regions(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewRegionClient(api)
 
 	if _, err := client.ListRegions(); err != nil {

--- a/volume_test.go
+++ b/volume_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_Volume(t *testing.T) {
 	apiKey := os.Getenv("LINODE_API_KEY")
-	api := lingo.NewAPIClient(apiKey)
+	api := lingo.NewAPIClient(apiKey, nil)
 	client := lingo.NewVolumeClient(api)
 
 	existing, err := client.ListVolumes()


### PR DESCRIPTION
This adds the option of having exponential backoff on all API calls to Linode.

It also includes several other small changes and features that were missing, such as checking for valid error types and teasing out validation of enums.